### PR TITLE
check user record against additional constraint columns

### DIFF
--- a/lib/casino/activerecord_authenticator/version.rb
+++ b/lib/casino/activerecord_authenticator/version.rb
@@ -1,5 +1,5 @@
 module CASino
   class ActiveRecordAuthenticator
-    VERSION = '4.0.2'
+    VERSION = '4.1'
   end
 end

--- a/spec/casino_core/activerecord_authenticator_spec.rb
+++ b/spec/casino_core/activerecord_authenticator_spec.rb
@@ -123,7 +123,7 @@ describe CASino::ActiveRecordAuthenticator do
         end
 
         context 'when no extra attributes given' do
-          let(:extra_attributes) { nil }
+          let(:extra_attributes) { {} }
 
           it 'returns an empty hash for extra attributes' do
             subject.validate('test', 'testpassword')[:extra_attributes].should eq({})

--- a/spec/casino_core/activerecord_authenticator_spec.rb
+++ b/spec/casino_core/activerecord_authenticator_spec.rb
@@ -18,8 +18,18 @@ describe CASino::ActiveRecordAuthenticator do
       extra_attributes: extra_attributes
     }
   end
+
+  let(:constraint_columns) do
+    {
+        constraint_columns: {
+            is_active: true
+        }
+    }
+  end
+
   let(:faulty_options){ options.merge(table: nil) }
   let(:connection_as_string) { options.merge(connection: 'sqlite3:/tmp/casino-test-auth.sqlite') }
+  let(:constraint_columns_options){ options.merge(constraint_columns) }
   let(:user_class) { described_class::TmpcasinotestauthsqliteUser }
 
   subject { described_class.new(options) }
@@ -34,6 +44,7 @@ describe CASino::ActiveRecordAuthenticator do
         create_table :users do |t|
           t.string :username
           t.string :password
+          t.string :is_active
           t.string :mail_address
         end
       end
@@ -230,6 +241,64 @@ describe CASino::ActiveRecordAuthenticator do
       end
     end
 
+    context 'support for additional_constraint_column' do
+      subject { described_class.new(constraint_columns_options) }
+
+      context 'when is_active is not present' do
+        before do
+          user_class.create!(
+              username: 'test6',
+              password: 'testpassword6',
+              mail_address: 'mail@example.org')
+        end
+
+        it 'is able to take additional_constraint_column into consideration' do
+          subject.validate('test6', 'testpassword6').should eq(false)
+        end
+      end
+
+      context 'when is_active is nil' do
+        before do
+          user_class.create!(
+              username: 'test6',
+              password: 'testpassword6',
+              is_active: nil,
+              mail_address: 'mail@example.org')
+        end
+
+        it 'is able to take additional_constraint_column into consideration' do
+          subject.validate('test6', 'testpassword6').should eq(false)
+        end
+      end
+
+      context 'when is_active is true' do
+        before do
+          user_class.create!(
+              username: 'test6',
+              password: 'testpassword6',
+              is_active: true,
+              mail_address: 'mail@example.org')
+        end
+
+        it 'is able to take additional_constraint_column into consideration' do
+          subject.validate('test6', 'testpassword6').should be_instance_of(Hash)
+        end
+      end
+
+      context 'when is_active is false' do
+        before do
+          user_class.create!(
+              username: 'test6',
+              password: 'testpassword6',
+              is_active: false,
+              mail_address: 'mail@example.org')
+        end
+
+        it 'is able to take additional_constraint_column into consideration' do
+          subject.validate('test6', 'testpassword6').should eq(false)
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Specify additional column names and expected values so that when fetching a user record, the additional columns and its values are checked against to validate user record.

For instance, this is useful for respecting an 'active' flag on user record so that only 'active' users can log in.

**Pivotal**: https://www.pivotaltracker.com/story/show/116243619