### PR TITLE
SSO - Add flag for allowing case insensitive plaintext passwords

### DIFF
--- a/lib/casino/activerecord_authenticator.rb
+++ b/lib/casino/activerecord_authenticator.rb
@@ -110,7 +110,12 @@ class CASino::ActiveRecordAuthenticator
   end
 
   def valid_password_as_plaintext?(password, password_from_database)
-    password == password_from_database
+    if @options.fetch(:plaintext_case_sensitive_password, false)
+      password == password_from_database
+    else
+      password.casecmp(password_from_database) == 0
+    end
+
   end
 
   def extra_attributes(user)

--- a/lib/casino/activerecord_authenticator/version.rb
+++ b/lib/casino/activerecord_authenticator/version.rb
@@ -1,5 +1,5 @@
 module CASino
   class ActiveRecordAuthenticator
-    VERSION = '4.1'
+    VERSION = '4.2'
   end
 end

--- a/spec/casino_core/activerecord_authenticator_spec.rb
+++ b/spec/casino_core/activerecord_authenticator_spec.rb
@@ -196,7 +196,7 @@ describe CASino::ActiveRecordAuthenticator do
       before do
         user_class.create!(
           username: 'test4',
-          password: '$P$9IQRaTwmfeRo7ud9Fh4E2PdI0S3r.L0', # password: test12345
+          password: Phpass.new().hash('test12345'),
           mail_address: 'mail@example.org')
       end
 
@@ -299,6 +299,54 @@ describe CASino::ActiveRecordAuthenticator do
         end
       end
     end
+
+    context 'support for plaintext_case_sensitive_password' do
+      context 'when plaintext_case_sensitive_password is true' do
+        subject { described_class.new(options.merge({plaintext_case_sensitive_password: true})) }
+        before do
+          user_class.create!(
+              username: 'test6',
+              password: 'testpassword6',
+              mail_address: 'mail@example.org')
+        end
+
+        it 'matches password exactly' do
+          subject.validate('test6', 'testpassword6').should be_instance_of(Hash)
+        end
+
+        it 'does not match password with different case' do
+          subject.validate('test6', 'tesTPasswOrd6').should eq(false)
+        end
+
+        it 'does not match wrong password' do
+          subject.validate('test6', 'testpassword5').should eq(false)
+        end
+      end
+
+      context 'when plaintext_case_sensitive_password is false' do
+        subject { described_class.new(options.merge({plaintext_case_sensitive_password: false})) }
+
+        before do
+          user_class.create!(
+              username: 'test6',
+              password: 'testpassword6',
+              mail_address: 'mail@example.org')
+        end
+
+        it 'matches password exactly' do
+          subject.validate('test6', 'testpassword6').should be_instance_of(Hash)
+        end
+
+        it 'matches password with different case' do
+          subject.validate('test6', 'tesTPasswOrd6').should be_instance_of(Hash)
+        end
+
+        it 'does not match wrong password' do
+          subject.validate('test6', 'testpassword5').should eq(false)
+        end
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
This branch adds functionality to allow for case insensitive plaintext passwords when authenticating via SSO.

## Pivotal
* https://www.pivotaltracker.com/story/show/120292563

## Documentation
* None

## How to test
* Visit https://ssostaging.vin65.com
  * Log in successfully using your username and password 
  * Log in successfully using your username and lower, upper, or mixed case of your existing password
  * Try logging in **unsuccessfully** using your username and modified password so the difference is more than just the casing

## Screenshots / Recordings
* None